### PR TITLE
hotfix/metamask-modals

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,13 @@
+{
+  "name": "frontend",
+  "version": "0.1.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "detect-browser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/detect-browser/-/detect-browser-3.0.0.tgz",
+      "integrity": "sha512-ykq76dexT6GiaHuaQxJ7Cd0B/xe/8VDLCpaWw4qCWKhWV/zjdY7r7BByBGNcgTlruOEyzFf0q1AAX7/yWeep8g=="
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "carbon-icons": "^7.0.7",
     "classnames": "^2.2.5",
     "dayjs": "^1.6.3",
+    "detect-browser": "^3.0.0",
     "gridlex": "^2.7.1",
     "history": "^4.7.2",
     "include-media": "^1.4.9",

--- a/src/App.js
+++ b/src/App.js
@@ -1,3 +1,6 @@
+/* eslint-disable camelcase */
+/* eslint-disable class-methods-use-this */
+
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
@@ -14,16 +17,22 @@ import AppHeader from './components/AppHeader';
 import NavigationBar from './components/NavigationBar';
 import MetamaskBooting from './components/MetamaskBooting';
 import MetamaskLogin from './components/MetamaskLogin';
+import BrowserNotSupported from './components/BrowserNotSupported';
 
 import * as actions from './actions';
 import { MYBIT_TICKER_COINMARKETCAP, ETHEREUM_TICKER_COINMARKETCAP } from './constants';
 
 import isMetaMask from './util/isMetamask';
-import checkAccount from './util/isUserLogged.js';
+import checkAccount from './util/isUserLogged';
+
+const { detect } = require('detect-browser');
 
 class App extends Component {
-  state = {
-    isMetamaskUserLogged: null,
+  constructor(props) {
+    super(props);
+    this.state = {
+      isMetamaskUserLogged: null,
+    };
   }
 
   UNSAFE_componentWillMount() {
@@ -38,27 +47,41 @@ class App extends Component {
   }
 
   componentDidMount() {
-    checkAccount().then(haveAccounts => {
+    checkAccount().then((haveAccounts) => {
       if (haveAccounts.length === 0) {
-        this.setState({ isMetamaskUserLogged: false })
+        this.setState({ isMetamaskUserLogged: false });
       }
-    })
+    });
+  }
+
+  isBrowserSupported() {
+    const browser = detect();
+    const supportedBrowsers = [
+      'chrome',
+      'opera',
+      'brave',
+      'firefox',
+    ];
+    if (supportedBrowsers.includes(browser.name)) {
+      return true;
+    }
+    return false;
   }
 
   // if Metamask is not established, modal is displayed with directions
   renderMetamaskWarrning() {
-    if(!isMetaMask()) {
-      return (
-        <MetamaskBooting />
-      );
+    if (!this.isBrowserSupported()) {
+      return <BrowserNotSupported />;
     }
+    if (!isMetaMask()) {
+      return <MetamaskBooting />;
+    }
+    return null;
   }
-
- 
 
   render() {
     const { state, setTransactionHistoryFilters, fetchTransactionHistory } = this.props;
-  
+
     return (
       <div>
         <AppHeader
@@ -66,7 +89,7 @@ class App extends Component {
         />
         <NavigationBar currentPath={this.props.location.pathname} />
         {this.renderMetamaskWarrning()}
-        {(this.state.isMetamaskUserLogged === false) ? <MetamaskLogin/> : null }
+        {(this.state.isMetamaskUserLogged === false) ? <MetamaskLogin /> : null }
         <div className="page-wrapper">
           <Switch>
             <Route exact path="/" component={() => <Redirect to="/explore" />} />

--- a/src/App.js
+++ b/src/App.js
@@ -1,5 +1,4 @@
 /* eslint-disable camelcase */
-/* eslint-disable class-methods-use-this */
 
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
@@ -15,26 +14,12 @@ import PortfolioPage from './components/pages/PortfolioPage';
 import TransactionHistoryPage from './components/pages/TransactionHistoryPage';
 import AppHeader from './components/AppHeader';
 import NavigationBar from './components/NavigationBar';
-import MetamaskBooting from './components/MetamaskBooting';
-import MetamaskLogin from './components/MetamaskLogin';
-import BrowserNotSupported from './components/BrowserNotSupported';
+import MetamaskChecker from './components/MetamaskChecker';
 
 import * as actions from './actions';
 import { MYBIT_TICKER_COINMARKETCAP, ETHEREUM_TICKER_COINMARKETCAP } from './constants';
 
-import isMetaMask from './util/isMetamask';
-import checkAccount from './util/isUserLogged';
-
-const { detect } = require('detect-browser');
-
 class App extends Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      isMetamaskUserLogged: null,
-    };
-  }
-
   UNSAFE_componentWillMount() {
     this.props.fetchPriceFromCoinmarketcap(MYBIT_TICKER_COINMARKETCAP);
     this.props.fetchPriceFromCoinmarketcap(ETHEREUM_TICKER_COINMARKETCAP);
@@ -46,39 +31,6 @@ class App extends Component {
     }, timeout);
   }
 
-  componentDidMount() {
-    checkAccount().then((haveAccounts) => {
-      if (haveAccounts.length === 0) {
-        this.setState({ isMetamaskUserLogged: false });
-      }
-    });
-  }
-
-  isBrowserSupported() {
-    const browser = detect();
-    const supportedBrowsers = [
-      'chrome',
-      'opera',
-      'brave',
-      'firefox',
-    ];
-    if (supportedBrowsers.includes(browser.name)) {
-      return true;
-    }
-    return false;
-  }
-
-  // if Metamask is not established, modal is displayed with directions
-  renderMetamaskWarrning() {
-    if (!this.isBrowserSupported()) {
-      return <BrowserNotSupported />;
-    }
-    if (!isMetaMask()) {
-      return <MetamaskBooting />;
-    }
-    return null;
-  }
-
   render() {
     const { state, setTransactionHistoryFilters, fetchTransactionHistory } = this.props;
 
@@ -88,8 +40,7 @@ class App extends Component {
           state={this.props.state}
         />
         <NavigationBar currentPath={this.props.location.pathname} />
-        {this.renderMetamaskWarrning()}
-        {(this.state.isMetamaskUserLogged === false) ? <MetamaskLogin /> : null }
+        <MetamaskChecker />
         <div className="page-wrapper">
           <Switch>
             <Route exact path="/" component={() => <Redirect to="/explore" />} />

--- a/src/components/BrowserNotSupported.js
+++ b/src/components/BrowserNotSupported.js
@@ -1,0 +1,27 @@
+import React from 'react';
+import { Modal, Button } from 'carbon-components-react';
+import '../styles/BrowserNotSupported.css';
+import MetamaskLogo from '../images/metamask.svg';
+
+const BrowserNotSupported = () => (
+  <Modal className="BrowserNotSupported" open passiveModal>
+    <p className="BrowserNotSupported__title">
+        Download Metamask <br /> to get started.
+    </p>
+    <img className="BrowserNotSupported__metamaskfox-image" src={MetamaskLogo} alt="Metamask" />
+    <p className="BrowserNotSupported__download-text">Download the browser extension on
+      <a href="https://www.google.com/chrome/" target="_blank" rel="noopener noreferrer"> Chrome</a>,
+      <a href="https://www.mozilla.org/en-US/firefox/new/" target="_blank" rel="noopener noreferrer"> Firefox</a>,
+      <a href="https://www.opera.com/" target="_blank" rel="noopener noreferrer"> Opera</a> or
+      <a href="https://brave.com/download/" target="_blank" rel="noopener noreferrer"> Brave</a>
+        .
+    </p>
+    <Button small className="BrowserNotSupported__metamasklogin-button">
+        Your browser is not supported
+    </Button>
+    <br />
+    <br />
+  </Modal>
+);
+
+export default BrowserNotSupported;

--- a/src/components/MetamaskBooting.js
+++ b/src/components/MetamaskBooting.js
@@ -3,29 +3,26 @@ import { Modal, Button } from 'carbon-components-react';
 import '../styles/MetamaskAudit.css';
 import MetamaskLogo from '../images/metamask.svg';
 
-class MetamaskBooting extends React.Component {
-    render() {
-      return(
-          <Modal className="MetamaskAudit" open passiveModal>
-            <p className="MetamaskAudit__title">
-            To start investing, please <br/> connect your wallet.
-            </p>
-            <img className="MetamaskAudit__metamaskfox-image" src={MetamaskLogo} alt="Metamask" />
-            <Button small className="MetamaskAudit__metamaskinstall-button">
-              Install Metamask and refresh
-            </Button>
-            <br/>
-            <Button small kind="secondary" className="MetamaskAudit__metamaskmanual-button">
-              What is Metamask?
-            </Button>
-            <br/>
-            <Button small kind="ghost" className="MetamaskAudit__metamaskfriendlyguide-link">
-              Try our handy step-by-step guide
-            </Button>
-          </Modal>
-        )
-    }
-
-}
+const MetamaskBooting = () => (
+  <Modal className="MetamaskAudit" open passiveModal>
+    <p className="MetamaskAudit__title">
+        To start investing, please <br /> connect your wallet.
+    </p>
+    <img className="MetamaskAudit__metamaskfox-image" src={MetamaskLogo} alt="Metamask" />
+    <div small className="MetamaskAudit__metamaskinstall-button">
+          Install Metamask and refresh
+    </div>
+    <br />
+    <a href="https://metamask.io/" target="_blank" rel="noopener noreferrer">
+      <Button small kind="secondary" className="MetamaskAudit__metamaskmanual-button">
+          What is Metamask?
+      </Button>
+    </a>
+    <br />
+    <a className="MetamaskAudit__metamaskfriendlyguide-link" href="https://metamask.io/" target="_blank" rel="noopener noreferrer">
+        Try our handy step-by-step guide
+    </a>
+  </Modal>
+);
 
 export default MetamaskBooting;

--- a/src/components/MetamaskBooting.js
+++ b/src/components/MetamaskBooting.js
@@ -1,28 +1,42 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { Modal, Button } from 'carbon-components-react';
 import '../styles/MetamaskAudit.css';
 import MetamaskLogo from '../images/metamask.svg';
 
-const MetamaskBooting = () => (
+const MetamaskBooting = ({ isBraveBrowser, extensionUrl }) => (
   <Modal className="MetamaskAudit" open passiveModal>
     <p className="MetamaskAudit__title">
-        To start investing, please <br /> connect your wallet.
+      {isBraveBrowser ?
+        <p>To start investing, please <br /> install Metamask.</p> :
+        <p>To start investing, please <br /> connect your wallet.</p>
+      }
     </p>
     <img className="MetamaskAudit__metamaskfox-image" src={MetamaskLogo} alt="Metamask" />
-    <div small className="MetamaskAudit__metamaskinstall-button">
-          Install Metamask and refresh
-    </div>
-    <br />
+    {!isBraveBrowser &&
+      <div>
+        <a href={extensionUrl} target="_blank" rel="noopener noreferrer">
+          <Button small kind="primary" className="MetamaskAudit__metamaskinstall-button">
+              Install Metamask and Refresh
+          </Button>
+        </a>
+        <br />
+      </div>
+    }
     <a href="https://metamask.io/" target="_blank" rel="noopener noreferrer">
       <Button small kind="secondary" className="MetamaskAudit__metamaskmanual-button">
           What is Metamask?
       </Button>
     </a>
     <br />
-    <a className="MetamaskAudit__metamaskfriendlyguide-link" href="https://metamask.io/" target="_blank" rel="noopener noreferrer">
-        Try our handy step-by-step guide
-    </a>
   </Modal>
 );
 
+MetamaskBooting.propTypes = {
+  isBraveBrowser: PropTypes.bool.isRequired,
+  extensionUrl: PropTypes.string.isRequired,
+};
+
+
 export default MetamaskBooting;
+

--- a/src/components/MetamaskChecker.js
+++ b/src/components/MetamaskChecker.js
@@ -1,0 +1,63 @@
+/* eslint-disable class-methods-use-this */
+
+import React, { Component } from 'react';
+import MetamaskBooting from './MetamaskBooting';
+import MetamaskLogin from './MetamaskLogin';
+import BrowserNotSupported from './BrowserNotSupported';
+import isMetaMask from '../util/isMetamask';
+import checkAccount from '../util/isUserLogged';
+
+const { detect } = require('detect-browser');
+
+class MetamaskChecker extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      isMetamaskUserLogged: null,
+    };
+  }
+
+  componentDidMount() {
+    checkAccount().then((haveAccounts) => {
+      if (haveAccounts.length === 0) {
+        this.setState({ isMetamaskUserLogged: false });
+      }
+    });
+  }
+
+  isBrowserSupported() {
+    const browser = detect();
+    const supportedBrowsers = [
+      'chrome',
+      'opera',
+      'brave',
+      'firefox',
+    ];
+    if (supportedBrowsers.includes(browser.name)) {
+      return true;
+    }
+    return false;
+  }
+
+  // if Metamask is not established, modal is displayed with directions
+  renderMetamaskWarrning() {
+    if (!this.isBrowserSupported()) {
+      return <BrowserNotSupported />;
+    }
+    if (!isMetaMask()) {
+      return <MetamaskBooting />;
+    }
+    return null;
+  }
+
+  render() {
+    return (
+      <div>
+        {this.renderMetamaskWarrning()}
+        {this.state.isMetamaskUserLogged === false ? <MetamaskLogin /> : null }
+      </div>
+    );
+  }
+}
+
+export default MetamaskChecker;

--- a/src/components/MetamaskLogin.js
+++ b/src/components/MetamaskLogin.js
@@ -2,51 +2,51 @@ import React from 'react';
 import { Modal, Button } from 'carbon-components-react';
 import '../styles/MetamaskLogin.css';
 import MetamaskLogo from '../images/metamask.svg';
-import checkAccount from '../util/isUserLogged.js';
+import checkAccount from '../util/isUserLogged';
 
 class MetamaskLogin extends React.Component {
-    state = {
+  constructor(props) {
+    super(props);
+    this.state = {
       isOpen: true,
-    }
+    };
+  }
 
-    componentDidMount() {
-      const checkInterval = 1000;
-      this.interval = setInterval(
-        () => {
-          checkAccount().then(haveAccounts => {
-            if (haveAccounts.length === 0) {
-              this.setState({ isOpen: true })
-            }
-            if (haveAccounts.length !== 0) {
-              this.setState({ isOpen: false })
-            }
-          })
-        }, checkInterval)
-    }
+  componentDidMount() {
+    const checkInterval = 1000;
+    this.interval = setInterval(() => {
+      checkAccount().then((haveAccounts) => {
+        if (haveAccounts.length === 0) {
+          this.setState({ isOpen: true });
+        }
+        if (haveAccounts.length !== 0) {
+          this.setState({ isOpen: false });
+        }
+      });
+    }, checkInterval);
+  }
 
-    componentWillUnmount() {
-      clearInterval(this.interval);
-    }
+  componentWillUnmount() {
+    clearInterval(this.interval);
+  }
 
-    render() {
-      return(
-          <Modal className="MetamaskLogin" open={this.state.isOpen} passiveModal>
-            <p className="MetamaskLogin__title">
-              To start investing, please <br/> login within the wallet.
-            </p>
-            <img className="MetamaskLogin__metamaskfox-image" src={MetamaskLogo} alt="Metamask" />
-            <Button small className="MetamaskLogin__metamasklogin-button">
-              Login within Metamask
-            </Button>
-            <br/>
-            <br/>
-            <Button small kind="ghost" className="MetamaskLogin__metamaskfriendlyguide-link">
-              I'll do this later
-            </Button>
-          </Modal>
-        )
-    }
-
+  render() {
+    return (
+      <Modal className="MetamaskLogin" open={this.state.isOpen} passiveModal>
+        <p className="MetamaskLogin__title">
+              To start investing, please <br /> unlock your wallet.
+        </p>
+        <img className="MetamaskLogin__metamaskfox-image" src={MetamaskLogo} alt="Metamask" />
+        <a href="https://www.youtube.com/watch?time_continue=25&v=6Gf_kRE4MJU" target="_blank" rel="noopener noreferrer">
+          <Button small className="MetamaskLogin__metamasklogin-button">
+                Click here to see how
+          </Button>
+        </a>
+        <br />
+        <br />
+      </Modal>
+    );
+  }
 }
 
 export default MetamaskLogin;

--- a/src/components/MetamaskLogin.js
+++ b/src/components/MetamaskLogin.js
@@ -34,7 +34,7 @@ class MetamaskLogin extends React.Component {
     return (
       <Modal className="MetamaskLogin" open={this.state.isOpen} passiveModal>
         <p className="MetamaskLogin__title">
-              To start investing, please <br /> unlock your wallet.
+              To start investing, please <br /> login to Metamask.
         </p>
         <img className="MetamaskLogin__metamaskfox-image" src={MetamaskLogo} alt="Metamask" />
         <a href="https://www.youtube.com/watch?time_continue=25&v=6Gf_kRE4MJU" target="_blank" rel="noopener noreferrer">

--- a/src/components/pages/TransactionHistoryPage.js
+++ b/src/components/pages/TransactionHistoryPage.js
@@ -1,3 +1,5 @@
+/* eslint-disable camelcase */
+
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Table, TableHead, TableRow, TableHeader, TableBody, TableData, PaginationV2 } from 'carbon-components-react';

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -1,3 +1,5 @@
+/* eslint-disable no-console */
+
 export const ARTIFICIAL_DELAY_IN_MS = 3000;
 export const USD_MYB_SYMBOL = 'USD/MYB';
 export const noop = () => {};

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -11,4 +11,6 @@ export const ETHERSCAN_API_KEY = '';
 export const ETHERSCAN_TX_BY_ADDR_ENDPOINT =
   (apiKey, address) =>
     `http://api-ropsten.etherscan.io/api?module=account&action=txlist&address=${address}&sort=asc&apikey=${apiKey}`;
-
+export const METAMASK_FIREFOX = 'https://addons.mozilla.org/en-US/firefox/addon/ether-metamask/';
+export const METAMASK_CHROME = 'https://chrome.google.com/webstore/detail/metamask/nkbihfbeogaeaoehlefnkodbefgpgknn';
+export const METAMASK_OPERA = 'http://addons.opera.com/extensions/details/metamask/';

--- a/src/styles/BrowserNotSupported.scss
+++ b/src/styles/BrowserNotSupported.scss
@@ -1,0 +1,34 @@
+@import '../styles/MetamaskModals.scss';
+
+.BrowserNotSupported {
+    border-top: none;
+
+    &__title {
+      @extend %metamask__title;
+    }
+
+    &__download-text{
+      width: 300px;
+      font-size: 18px;
+      line-height: 1;
+      text-align: center;
+      margin: 0 auto;
+      margin-bottom: 30px;
+
+      & a{
+        text-decoration: none;
+        color: #1991eb;
+      }
+    }
+
+    &__metamaskfox-image {
+      @extend %metamask__image;
+    }
+
+    &__metamasklogin-button {
+      width: 86%;
+      margin-left: 7%;
+      margin-right: 7%;
+      cursor: default;
+    }
+}

--- a/src/styles/MetamaskAudit.scss
+++ b/src/styles/MetamaskAudit.scss
@@ -1,105 +1,48 @@
-// carbon override; it should be better way
-.bx--modal-container {
-  border-top: none;
-  padding: 0;
-  min-width: 325px;
-}
-
-.bx--modal-content {
-  margin-bottom: 1rem;
-  margin-top: 1rem;
-}
-
-.bx--modal-close {
-  top: 0.4rem;
-  right: 0.6rem;
-}
-
-.bx--modal-close__icon {
-  fill: #2e58db;
-  width: 1.5rem;
-  height: 1.5rem;
-}
-
-
-// BUTTONS
-.bx--btn--primary {
-  background-color: #2e58db;
-  font-family: 'Roboto';
-
-  &:hover {
-    background-color: #2e58db;
-  }
-  &:active {
-    border: #2e58db;
-  }
-  &:visited {
-    border: #2e58db;
-    background-color: #2e58db;
-  }
-}
-
-.bx--btn--secondary {
-  border-color: #2e58db;
-  color: #2e58db;
-  font-family: 'Roboto';
-
-  &:hover {
-    background-color: #2e58db;
-  }
-}
-
-.bx--btn--ghost {
-  color: #2e58db;
-  font-family: 'Roboto';
-  font-weight: 200;
-
-  &:hover {
-    background-color: #2e58db;
-    border: none;
-  }
-}
-// end of BUTTONS
-
-
-// end of carbon override
+@import '../styles/MetamaskModals.scss';
 
 .MetamaskAudit {
     border-top: none;
 
     &__title {
-      font-size: 1.1rem;
-      font-family: 'gilroy-extrabold';
-      color: rgba(0, 0, 0, 0.75);
-      font-weight: 700;
-      text-align: center;
-      line-height: 1.5rem;
+      @extend %metamask__title;
     }
 
     &__metamaskfox-image {
-      display: block;
-      margin-left: auto;
-      margin-right: auto;
-      width: 54%;
-      margin-bottom: 20px;
-      margin-top: 15px;
+      @extend %metamask__image;
     }
 
-    &__metamaskinstall-button, &__metamaskfriendlyguide-link {
+    &__metamaskinstall-button {
       width: 86%;
       margin-left: 7%;
       margin-right: 7%;
-      margin-bottom: 10px;
+      background-color: #2e58db;
+      align-items: center;
+      justify-content: center;
+      /* flex-shrink: 0; */
+      font-size: .875rem;
+      font-weight: 600;
+      height: 2.5rem;
+      padding: 0 1rem;
+      text-decoration: none;
+      line-height: 16px;
+      display: flex;
+      color: white;
     }
 
     &__metamaskmanual-button {
       width: 86%;
       margin-left: 7%;
       margin-right: 7%;
+
+      & a{
+        text-decoration: none;
+      }
     }
 
     &__metamaskfriendlyguide-link {
-      margin-top: 0.3rem;
-      text-decoration: underline;
+      margin-top: 20px;
+      display: block;
+      text-align: center;
+      color: black;
     }
 }

--- a/src/styles/MetamaskAudit.scss
+++ b/src/styles/MetamaskAudit.scss
@@ -15,18 +15,7 @@
       width: 86%;
       margin-left: 7%;
       margin-right: 7%;
-      background-color: #2e58db;
-      align-items: center;
-      justify-content: center;
-      /* flex-shrink: 0; */
-      font-size: .875rem;
-      font-weight: 600;
-      height: 2.5rem;
-      padding: 0 1rem;
-      text-decoration: none;
-      line-height: 16px;
-      display: flex;
-      color: white;
+      margin-bottom: 10px;
     }
 
     &__metamaskmanual-button {
@@ -37,12 +26,5 @@
       & a{
         text-decoration: none;
       }
-    }
-
-    &__metamaskfriendlyguide-link {
-      margin-top: 20px;
-      display: block;
-      text-align: center;
-      color: black;
     }
 }

--- a/src/styles/MetamaskLogin.scss
+++ b/src/styles/MetamaskLogin.scss
@@ -1,97 +1,23 @@
-// carbon override; it should be better way
-.bx--modal-container {
+@import '../styles/MetamaskModals.scss';
+
+.MetamaskLogin {
     border-top: none;
-    padding: 0;
-    min-width: 325px;
-  }
-  
-  .bx--modal-content {
-    margin-bottom: 1rem;
-    margin-top: 1rem;
-  }
-  
-  .bx--modal-close {
-    top: 0.4rem;
-    right: 0.6rem;
-  }
-  
-  .bx--modal-close__icon {
-    fill: #2e58db;
-    width: 1.5rem;
-    height: 1.5rem;
-  }
-  
-  
-  // BUTTONS
-  .bx--btn--primary {
-    background-color: #2e58db;
-    font-family: 'Roboto';
-  
-    &:hover {
-      background-color: #2e58db;
+
+    &__title {
+      @extend %metamask__title;
     }
-    &:active {
-      border: #2e58db;
+
+    &__metamaskfox-image {
+      @extend %metamask__image;
     }
-    &:visited {
-      border: #2e58db;
-      background-color: #2e58db;
+
+    &__metamasklogin-button, &__metamaskfriendlyguide-link {
+      width: 86%;
+      margin-left: 7%;
+      margin-right: 7%;
     }
-  }
-  
-  .bx--btn--secondary {
-    border-color: #2e58db;
-    color: #2e58db;
-    font-family: 'Roboto';
-  
-    &:hover {
-      background-color: #2e58db;
+
+    &__metamaskfriendlyguide-link {
+      text-decoration: underline;
     }
-  }
-  
-  .bx--btn--ghost {
-    color: #2e58db;
-    font-family: 'Roboto';
-    font-weight: 200;
-  
-    &:hover {
-      background-color: #2e58db;
-      border: none;
-    }
-  }
-  // end of BUTTONS
-  
-  
-  // end of carbon override
-  
-  .MetamaskLogin {
-      border-top: none;
-  
-      &__title {
-        font-size: 1.1rem;
-        font-family: 'gilroy-extrabold';
-        color: rgba(0, 0, 0, 0.75);
-        font-weight: 700;
-        text-align: center;
-        line-height: 1.5rem;
-      }
-  
-      &__metamaskfox-image {
-        display: block;
-        margin-left: auto;
-        margin-right: auto;
-        width: 54%;
-        margin-bottom: 20px;
-        margin-top: 15px;
-      }
-  
-      &__metamasklogin-button, &__metamaskfriendlyguide-link {
-        width: 86%;
-        margin-left: 7%;
-        margin-right: 7%;
-      }
-  
-      &__metamaskfriendlyguide-link {
-        text-decoration: underline;
-      }
-  }
+}

--- a/src/styles/MetamaskModals.scss
+++ b/src/styles/MetamaskModals.scss
@@ -1,0 +1,76 @@
+// carbon override; it should be better way
+.bx--modal-container {
+    border-top: none;
+    padding: 0;
+    min-width: 325px;
+  }
+
+  .bx--modal-content {
+    margin-bottom: 1rem;
+    margin-top: 1rem;
+  }
+
+  .bx--modal-close{
+    display: none;
+  }
+
+
+  // BUTTONS
+  .bx--btn--primary {
+    background-color: #2e58db;
+    font-family: 'Roboto';
+
+    &:hover {
+      background-color: #2e58db;
+    }
+    &:active {
+      border: #2e58db;
+    }
+    &:visited {
+      border: #2e58db;
+      background-color: #2e58db;
+    }
+  }
+
+  .bx--btn--secondary {
+    border-color: #2e58db;
+    color: #2e58db;
+    font-family: 'Roboto';
+
+    &:hover {
+      background-color: #2e58db;
+    }
+  }
+
+  .bx--btn--ghost {
+    color: #2e58db;
+    font-family: 'Roboto';
+    font-weight: 200;
+
+    &:hover {
+      background-color: #2e58db;
+      border: none;
+    }
+  }
+  // end of BUTTONS
+
+
+  // end of carbon override
+
+%metamask__title {
+  font-size: 1.1rem;
+  font-family: 'gilroy-extrabold';
+  color: rgba(0, 0, 0, 0.75);
+  font-weight: 700;
+  text-align: center;
+  line-height: 1.5rem;
+}
+
+%metamask__image{
+  display: block;
+  margin-left: auto;
+  margin-right: auto;
+  width: 54%;
+  margin-bottom: 20px;
+  margin-top: 15px;
+}

--- a/src/styles/MetamaskModals.scss
+++ b/src/styles/MetamaskModals.scss
@@ -22,11 +22,16 @@
 
     &:hover {
       background-color: #2e58db;
+      border: #2e58db;
     }
     &:active {
       border: #2e58db;
     }
     &:visited {
+      border: #2e58db;
+      background-color: #2e58db;
+    }
+    &:focus {
       border: #2e58db;
       background-color: #2e58db;
     }

--- a/src/util/isGlobalWeb3.js
+++ b/src/util/isGlobalWeb3.js
@@ -1,5 +1,5 @@
 function isGlobalWeb3() {
-  if (typeof window === "undefined") return false;
+  if (typeof window === 'undefined') return false;
   if (!window) return false;
   if (!window.web3) return false;
   if (!window.web3.currentProvider) return false;

--- a/src/util/isMetamask.js
+++ b/src/util/isMetamask.js
@@ -1,4 +1,4 @@
-var isGlobalWeb3 = require("./isGlobalWeb3");
+const isGlobalWeb3 = require('./isGlobalWeb3');
 
 function isMetaMask() {
   if (!isGlobalWeb3()) return false;

--- a/src/util/isUserLogged.js
+++ b/src/util/isUserLogged.js
@@ -1,10 +1,6 @@
 
 async function checkAccount() {
-  let accounts = await window.web3.eth.getAccounts().then(
-    accounts => {
-      return accounts;
-    }
-  )
+  const accounts = await window.web3.eth.getAccounts().then(accs => accs);
   return accounts;
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4615,6 +4615,10 @@ destroy@~1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/destroy/-/destroy-1.0.4.tgz#978857442c44749e4206613e37946205826abd80"
 
+detect-browser@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/detect-browser/-/detect-browser-3.0.0.tgz#3fc232002c56d427410a9e1ac3b3e8c3a80bb848"
+
 detect-indent@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/detect-indent/-/detect-indent-4.0.0.tgz#f76d064352cdf43a1cb6ce619c4ee3a9475de208"
@@ -10320,9 +10324,9 @@ react-is@^16.4.1:
   version "16.4.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.4.1.tgz#d624c4650d2c65dbd52c72622bbf389435d9776e"
 
-react-jazzicon@0.0.1:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/react-jazzicon/-/react-jazzicon-0.0.1.tgz#e8d1cdf434e1ce640b32d779d77452f335cb5f1b"
+react-jazzicon@^0.1.0:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/react-jazzicon/-/react-jazzicon-0.1.1.tgz#7b3412ba49f2630a02c8b47b1eaa09fb9e633e71"
   dependencies:
     mersenne-twister "^1.1.0"
     prop-types "^15.5.10"


### PR DESCRIPTION
Added a new modal for when the browser is not supported. Preview [here](https://puu.sh/B53mH/864095cbe2.png).

Removed the option to close the popups, since the platform is very much unusable without setting up metamask. 

Exported some shared css by these modals to a specific file to help with maintainability.

Preview of what the user sees when metamask is not logged in [here](https://puu.sh/B53qc/0ac5be3374.png).

Preview of what the user sees when metamask is not installed but it is a supported browser [here](https://puu.sh/B53pM/7ec03d7948.png).

Also made some of the buttons messages (look the same, just aren't clickable) since we can't really interact with Metamask programmatically to login, etc.