### PR TITLE
hotfix/address-loading

### DIFF
--- a/src/components/Address.js
+++ b/src/components/Address.js
@@ -7,9 +7,9 @@ import '../styles/Address.css';
 const Address = ({ userName, className }) => (
   <div className={className}>
     {!userName ? (
-      <div>
-        <Loading className="Address--is-loading" small withOverlay={false} />
-        <span className="Address__loading-message">Loading account</span>
+      <div className="Address__loader">
+        <Loading small withOverlay={false} />
+        <span>Loading account</span>
       </div>
       ) : (
         <div>

--- a/src/styles/Address.scss
+++ b/src/styles/Address.scss
@@ -3,6 +3,14 @@
 .Address{
   height: 39px;
 
+    &__loader{
+      display: flex;
+      position: relative;
+      justify-content: center;
+      align-items: center;
+      width: max-content;
+    }
+
     &__text{
         font-size: 14px;
         padding-left: 50px;
@@ -14,17 +22,6 @@
         margin: 0px 0px;
         position: relative;
         top: -25px;
-    }
-
-    &--is-loading{
-        position: absolute;
-        top: 28px;
-    }
-
-    &__loading-message{
-        padding-left: 32px;
-        position: relative;
-        top: 12px;
     }
 }
 


### PR DESCRIPTION
Addresses [this](https://puu.sh/B5U6j/70ebe9fd48.png) problem. Although this case should never happen, as the page is only displayed once we have all the asset information. Still, the CSS was wrong for this one.