### PR TITLE
hotfix/pulling-etherscan

### DIFF
--- a/src/apis/brain.js
+++ b/src/apis/brain.js
@@ -36,7 +36,7 @@ export const fetchTransactionHistory = async user => new Promise(async (resolve,
     const endpoint = ETHERSCAN_TX_BY_ADDR_ENDPOINT(ETHERSCAN_API_KEY, userAddress);
     const result = await fetch(endpoint);
     const jsonResult = await result.json();
-    if (jsonResult.status === '1') {
+    if (!jsonResult.message || (jsonResult.message && jsonResult.message !== "No transactions found" && jsonResult.message !== "OK")) {
       throw new Error(jsonResult.result);
     }
 


### PR DESCRIPTION
So etherscan has a bit of a weird thing going on.

If you have no transactions on a given address then their response returns status = 0; 
If you do have transactions then the response returns status = 1;

Go figure.

So I changed the condition we are used to check whether we can use their response. Works for both cases.