### PR TITLE
hotfix/decimals

### DIFF
--- a/src/apis/brain.js
+++ b/src/apis/brain.js
@@ -252,7 +252,7 @@ export const fetchAssets = async (user, currentEthInUsd) => new Promise(async (r
       const jsonResponse = await ipfsInfo.json();
       return {
         ...asset,
-        amountRaisedInUSD: String(Number(web3.utils.fromWei(amountsRaised[index], 'ether')) * currentEthInUsd),
+        amountRaisedInUSD: (Number(web3.utils.fromWei(amountsRaised[index], 'ether')) * currentEthInUsd).toFixed(2),
         amountToBeRaisedInUSD: amountsToBeRaised[index],
         fundingDeadline: Number(fundingDeadlines[index]) * 1000,
         ownershipUnits: ownershipUnits[index],

--- a/src/components/AssetDetails.js
+++ b/src/components/AssetDetails.js
@@ -125,8 +125,9 @@ class AssetDetails extends React.Component {
 
   render() {
     const maxInvestment = this.state.daysToGo < 0 ? 0 :
-      this.props.information.goal - this.props.information.raised;
-    const ownership = (this.state.currentSelectedAmount * 100) / this.props.information.goal;
+      (this.props.information.goal - this.props.information.raised).toFixed(2);
+    const ownership = ((this.state.currentSelectedAmount * 100) /
+      this.props.information.goal).toFixed(2);
     this.etherValueSelected = Number((this.state.currentSelectedAmount / this.props.currentEthInUsd)
       .toFixed(2));
     let minInvestment = this.state.daysToGo < 0 || maxInvestment === 0 ? 0 : 100;

--- a/src/components/ConfirmationPopup.js
+++ b/src/components/ConfirmationPopup.js
@@ -71,9 +71,9 @@ class ConfirmationPopup extends React.Component {
               style={{ lineHeight: '1', paddingTop: '15px' }}
             >
               Expected annual return:{' '}
-              <span className="ConfirmationPopup__description-amount">18%</span>
+              <span className="ConfirmationPopup__description-amount ConfirmationPopup__description-amount--is-inactive">18%</span>
             </p>
-            <p className="ConfirmationPopup__description-amount-right">$18,000</p>
+            <p className="ConfirmationPopup__description-amount-right ConfirmationPopup__description-amount-right--is-inactive">$18,000</p>
             <p className="ConfirmationPopup__description-amount-right">
               {this.props.amountEth} <b>ETH</b>
             </p>

--- a/src/styles/ConfirmationPopup.scss
+++ b/src/styles/ConfirmationPopup.scss
@@ -34,6 +34,10 @@
     font-size: 15px;
     font-weight: 700;
     color: black;
+
+    &--is-inactive{
+      color: #d9d9d9;
+    }
   }
 
   &__description-amount-right{
@@ -42,6 +46,10 @@
     font-size: 14px;
     font-weight: bold;
     color: black;
+
+    &--is-inactive{
+      color: #d9d9d9;
+    }
   }
 
   &__line{


### PR DESCRIPTION
We probably need to find a better way to round numbers other than using toFixed(2). Will look into this for the next version.

Also disabled the two variables related to asset income in the contribution popup, since they are currently hardcoded.